### PR TITLE
Use default relay

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -3,9 +3,6 @@
 # https://nwc.getalby.com/public/images/nwc-logo.svg
 
 #
-
-export RELAY="wss://relay.getalby.com/v1"
-
 export LN_BACKEND_TYPE="LND"
 export LND_ADDRESS="lnd.embassy:10009"      #the LND gRPC address, eg. localhost:10009 (used with the LND backend)
 export LND_CERT_FILE="/mnt/lnd/tls.cert"    #the location where LND's tls.cert file can be found (used with the LND backend)
@@ -15,9 +12,7 @@ export PORT=8080 #the port on which the app should listen on (default='blah' #80
 
 export TOR_ADDRESS=$(yq e '.tor-address' /data/start9/config.yaml)
 export LAN_ADDRESS=$(yq e '.lan-address' /data/start9/config.yaml)
-export RELAY=$(yq e ".nostr-relay" /data/start9/config.yaml)
 
-echo "Nostr Relay: " $RELAY
 echo "LN Backend Type: " $LN_BACKEND_TYPE
 echo "LN Address: " $LND_ADDRESS
 echo "LND Cert: " $LND_CERT_FILE

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -9,6 +9,7 @@ export LND_CERT_FILE="/mnt/lnd/tls.cert"    #the location where LND's tls.cert f
 export LND_MACAROON_FILE="/mnt/lnd/admin.macaroon" #the location where LND's admin.macaroon file can be found (used with the LND backend)
 export WORK_DIR="/data/albyhub"
 export PORT=8080 #the port on which the app should listen on (default='blah' #8080)
+export LOG_EVENTS=true # makes debugging easier
 
 export TOR_ADDRESS=$(yq e '.tor-address' /data/start9/config.yaml)
 export LAN_ADDRESS=$(yq e '.lan-address' /data/start9/config.yaml)

--- a/scripts/procedures/getConfig.ts
+++ b/scripts/procedures/getConfig.ts
@@ -24,13 +24,5 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
       "package-id": "albyhub",
       "target": "lan-address",
       "interface": "main",
-    },
-    "nostr-relay": {
-        "type": "string",
-        "name": "Nostr Relay",
-        "default": "wss://relay.getalby.com/v1",
-        "description": "The Nostr Relay to use for Albyhub connections",
-        "copyable": true,
-        "nullable": false,
     }
   });


### PR DESCRIPTION
somehow I had user reports that the relay was somehow blank. And I think the default is just good if there are more relay options in the future we can enabled it again.