### PR TITLE
use v1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/getalby/hub:latest
+FROM ghcr.io/getalby/hub:v1.2.0
 LABEL maintainer="andrewlunde <andrew.lunde@sap.com>"
 
 # Start9 Packaging

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 id: albyhub
 title: Alby Hub
-version: 0.6.2
+version: 1.2.0
 release-notes: Alby Hub initial release
 license: Apache-2.0
 wrapper-repo: "https://github.com/horologger/albyhub-startos"


### PR DESCRIPTION
this fixes the version to the current hub version v1.2.0 and keeps the packe version in sync with the hub version.

once the next hub version is releases this package also needs to be updated.